### PR TITLE
fix: Arch/Binary Name Compatibility

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -88,6 +88,9 @@ get_arch() {
 	x86_64)
 		echo amd64
 		;;
+	aarch64)
+		echo arm64
+		;;
 	*)
 		echo "$arch"
 		;;


### PR DESCRIPTION
Hello,

The Etcd project provides binaries compatible with Aarch64, but these are labeled with the arm64 prefix. The current get_arch function attempts to download files that do not exist. For example: https://github.com/etcd-io/etcd/releases/download/v3.5.11/etcd-v3.5.11-linux-aarch64.tar.gz.

This pull request (PR) modifies the code to correctly use the arm64 prefix for aarch64 binaries.

Thank you
